### PR TITLE
Only create data in tables when env var matches.

### DIFF
--- a/LiveTramsMCR/Configuration/AppConfiguration.Database.cs
+++ b/LiveTramsMCR/Configuration/AppConfiguration.Database.cs
@@ -14,4 +14,8 @@ public static partial class AppConfiguration
     public const string RoutesV2CollectionName = "routesV2";
 
     public const string RouteTimesCollectionName = "route-times";
+
+    public const string MigrationModeVariable = "MIGRATIONMODE";
+
+    public const string MigrationModeCreateValue = "CREATE";
 }

--- a/LiveTramsMCR/Startup.cs
+++ b/LiveTramsMCR/Startup.cs
@@ -85,9 +85,14 @@ public class Startup
             RoutesV2CollectionName = AppConfiguration.RoutesV2CollectionName,
             RoutesV2Path = AppConfiguration.RoutesV2Path
         };
-
-        var synchronizer = new Synchronizer();
-        synchronizer.SynchronizeStaticData(synchronizationRequest).Wait();
+        
+        var migrationMode = Environment.GetEnvironmentVariable(AppConfiguration.MigrationModeVariable);
+        if (migrationMode == AppConfiguration.MigrationModeCreateValue)
+        {
+            var synchronizer = new Synchronizer();
+            synchronizer.SynchronizeStaticData(synchronizationRequest).Wait();
+        }
+        
         
         var db = mongoClient.GetDatabase(AppConfiguration.DatabaseName);
         var stopsMongoCollection = db.GetCollection<Stop>(AppConfiguration.StopsCollectionName);

--- a/LiveTramsMCR/Startup.cs
+++ b/LiveTramsMCR/Startup.cs
@@ -70,26 +70,25 @@ public class Startup
 
         var mongoClient = new MongoClient(Configuration["CosmosConnectionString"]);
         
-        var synchronizationRequest = new SynchronizationRequest
-        {
-            MongoClient = mongoClient,
-            TargetDbName = AppConfiguration.DatabaseName,
-            StopsCollectionName = AppConfiguration.StopsCollectionName,
-            StopsPath = AppConfiguration.StopsPath,
-            StopsV2CollectionName = AppConfiguration.StopsV2CollectionName,
-            StopsV2Path = AppConfiguration.StopsV2Path,
-            RouteTimesCollectionName = AppConfiguration.RouteTimesCollectionName,
-            RouteTimesPath = AppConfiguration.RouteTimesPath,
-            RoutesCollectionName = AppConfiguration.RoutesCollectionName,
-            RoutesPath = AppConfiguration.RoutesPath,
-            RoutesV2CollectionName = AppConfiguration.RoutesV2CollectionName,
-            RoutesV2Path = AppConfiguration.RoutesV2Path
-        };
-        
         var migrationMode = Environment.GetEnvironmentVariable(AppConfiguration.MigrationModeVariable);
         if (migrationMode == AppConfiguration.MigrationModeCreateValue)
         {
             var synchronizer = new Synchronizer();
+            var synchronizationRequest = new SynchronizationRequest
+            {
+                MongoClient = mongoClient,
+                TargetDbName = AppConfiguration.DatabaseName,
+                StopsCollectionName = AppConfiguration.StopsCollectionName,
+                StopsPath = AppConfiguration.StopsPath,
+                StopsV2CollectionName = AppConfiguration.StopsV2CollectionName,
+                StopsV2Path = AppConfiguration.StopsV2Path,
+                RouteTimesCollectionName = AppConfiguration.RouteTimesCollectionName,
+                RouteTimesPath = AppConfiguration.RouteTimesPath,
+                RoutesCollectionName = AppConfiguration.RoutesCollectionName,
+                RoutesPath = AppConfiguration.RoutesPath,
+                RoutesV2CollectionName = AppConfiguration.RoutesV2CollectionName,
+                RoutesV2Path = AppConfiguration.RoutesV2Path
+            };
             synchronizer.SynchronizeStaticData(synchronizationRequest).Wait();
         }
         

--- a/docker-compose.run-local.yml
+++ b/docker-compose.run-local.yml
@@ -11,6 +11,7 @@ services:
       CosmosConnectionString: mongodb://foo:bar@mongo:27017/
       OcpApimSubscriptionKey: "<Your TfGM OpenData API OcpApimSubscriptionKey here>"
       ASPNETCORE_ENVIRONMENT: Development # Allow SwaggerUI
+      MIGRATIONMODE: CREATE # Create required data in mongodb on startup
   mongo:
     image: mongo
     restart: always


### PR DESCRIPTION
This will prevent re-running the check when the data exists when app service has a cold start.